### PR TITLE
kw-view-remove-product-listing

### DIFF
--- a/src/Bangazon.css
+++ b/src/Bangazon.css
@@ -8,6 +8,11 @@ body {
   margin-bottom: 10px;
 }
 
+.lineBreak {
+  width: 25%;
+  margin-left: 0;
+}
+
 .App {
   text-align: center;
 }

--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -33,6 +33,12 @@ const ApplicationViews = (props) => {
           return <ProductForm {...props} />;
         }}
       />
+      <Route 
+        path="/myproducts" 
+        render={props => {
+            return <MyProducts {...props}/>
+        }}
+      />
       <Route
         path="/products/:productId(\d+)"
         render={(props) => {

--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -15,6 +15,7 @@ import ProductForm from "./products/ProductForm";
 import ProductTypeList from "./products/ProductTypeList";
 import ProductList from "./products/ProductList";
 import Home from "./home/Home";
+import MyProducts from "./products/MyProducts";
 
 
 const ApplicationViews = (props) => {
@@ -26,6 +27,9 @@ const ApplicationViews = (props) => {
         }}/>
         <Route path="/addproduct" render={props => {
             return <ProductForm { ...props }/>
+        }}/>
+        <Route path="/myproducts" render={props => {
+            return <MyProducts {...props}/>
         }}/>
         <Route path="/products/:productId(\d+)" render={props => {
             return <ProductDetail productId={parseInt(props.match.params.productId)} { ...props }/>

--- a/src/components/home/HomeProductsCard.js
+++ b/src/components/home/HomeProductsCard.js
@@ -1,17 +1,20 @@
 import React from "react";
 import "./Home.css"
+import ProductTypeList from "../products/ProductTypeList";
 
 const HomeProductsCard = (props) => {
   return (
     <div className="card">
       <div className="card-content">
+        <p key={props.product.id} className="detail-link">
         <a
           onClick={() => {
             props.history.push(`/products/${props.product.id}`);
           }}
         >
-          <p>{props.product.title}</p>
+          {props.product.title}
         </a>
+        </p>
       </div>
     </div>
   );

--- a/src/components/nav/Nav.js
+++ b/src/components/nav/Nav.js
@@ -32,6 +32,7 @@ const NavBar = (props) => {
           {isAuthenticated() ? (
             <>
               {" "}
+              <Link to="/myproducts">My Products</Link>
               <Link to="/addproduct">Sell a Product</Link>
               <Link to="/order">View Cart</Link>
               <Link to="/myaccount">My Account</Link>

--- a/src/components/products/MyProducts.js
+++ b/src/components/products/MyProducts.js
@@ -1,0 +1,39 @@
+// user can view all products they currently have for sale
+import React, { useState, useEffect } from "react";
+import ProductManager from "../../modules/ProductManager";
+import useSimpleAuth from '../auth/useSimpleAuth';
+
+const MyProducts = (props) => {
+    const [products, setProducts] = useState([]);
+    const { isAuthenticated } = useSimpleAuth();
+
+    const getProducts = () => {
+        if(isAuthenticated()) {
+            ProductManager.getProductsByUser()
+            .then(result => {
+                setProducts(result)
+            })
+        }
+    };
+
+    useEffect(() => {
+        getProducts();
+    }, []);
+
+    return (
+        <div className="content">
+        <div>
+            <h2>My Current Listings</h2>
+            <div>
+                {products.map(product => 
+                    <p>{product.title}</p>
+                )}
+            </div>
+            </div>
+        </div>
+
+    )
+
+}
+
+export default MyProducts

--- a/src/components/products/MyProducts.js
+++ b/src/components/products/MyProducts.js
@@ -16,8 +16,14 @@ const MyProducts = (props) => {
         }
     };
 
+    const deleteProduct = (productId) => {
+        ProductManager.deleteProduct(productId)
+            .then(getProducts)
+    }
+
     useEffect(() => {
         getProducts();
+       
     }, []);
 
     return (
@@ -26,7 +32,11 @@ const MyProducts = (props) => {
             <h2>My Current Listings</h2>
             <div>
                 {products.map(product => 
+                    <div>
                     <p key={product.id} className="detail-link" onClick={() => props.history.push(`/products/${parseInt(product.id)}`)}>{product.title}</p>
+                    <button onClick={() => { deleteProduct(product.id) }}>Remove Listing</button>
+                    <hr className='lineBreak'></hr>
+                    </div>
                 )}
             </div>
             </div>

--- a/src/components/products/MyProducts.js
+++ b/src/components/products/MyProducts.js
@@ -26,7 +26,7 @@ const MyProducts = (props) => {
             <h2>My Current Listings</h2>
             <div>
                 {products.map(product => 
-                    <p>{product.title}</p>
+                    <p key={product.id} className="detail-link" onClick={() => props.history.push(`/products/${parseInt(product.id)}`)}>{product.title}</p>
                 )}
             </div>
             </div>

--- a/src/components/products/ProductDetails.js
+++ b/src/components/products/ProductDetails.js
@@ -7,7 +7,7 @@ import "./ProductDetails.css"
 const ProductDetail = (props) => {
     const [product, setProduct] = useState({ title: "", price: 0.00, description: "", quantity: 0, location: "", imagePath: "", productTypeId: 0 });
     const [productType, setProductType] = useState("")
-
+    
     useEffect(() => {
         ProductManager.getProductById(props.productId).then(product => {
             setProduct({

--- a/src/components/products/ProductListCard.js
+++ b/src/components/products/ProductListCard.js
@@ -5,8 +5,11 @@ const ProductListCard = props => {
 
     return (
         <>
-            <a key={parseInt(props.product.url.split('/')[4])}className="detail-link"onClick={() => props.history.push(`/products/${parseInt(props.product.url.split('/')[4])}`)}>
-            <p key={parseInt(props.product.url.split('/')[4])}><strong>{props.product.title}</strong> ({props.product.quantity}) ${(props.product.price).toFixed(2)}</p></a>
+            <p key={parseInt(props.product.url.split('/')[4])} className="detail-link">
+                <a className="detail-link" onClick={() => props.history.push(`/products/${parseInt(props.product.url.split('/')[4])}`)}>
+                    <strong>{props.product.title}</strong> ({props.product.quantity}) ${(props.product.price).toFixed(2)}
+                </a>
+            </p>
         </>
     )
 }

--- a/src/components/products/ProductType.css
+++ b/src/components/products/ProductType.css
@@ -4,6 +4,7 @@ h3 {
 
 .detail-link {
     cursor: pointer;
+    width: fit-content;
 }
 
 

--- a/src/components/products/ProductTypeCard.js
+++ b/src/components/products/ProductTypeCard.js
@@ -17,12 +17,12 @@ const ProductTypeCard = props => {
     return (
         <>
             <div>
-                <a onClick={() => props.history.push(`/categories/${props.productType.id}`)} className="detail-link"><h3>{props.productType.name} ({finalProductAmount})</h3></a>
+                <h3><a onClick={() => props.history.push(`/categories/${props.productType.id}`)} className="detail-link">{props.productType.name} ({finalProductAmount})</a></h3>
             
         
                 <ul>
                     {props.productType.products.slice(0, 3).map(product =>
-                        <a key={parseInt(product.url.split('/')[4])}className="detail-link"onClick={() => props.history.push(`/products/${parseInt(product.url.split('/')[4])}`)}><strong><li key={parseInt(product.url.split('/')[4])}>{product.title} ({product.quantity})</li></strong></a>
+                        <li key={parseInt(product.url.split('/')[4])} className="detail-link"><a key={parseInt(product.url.split('/')[4])} onClick={() => props.history.push(`/products/${parseInt(product.url.split('/')[4])}`)}><strong>{product.title} ({product.quantity})</strong></a></li>
                         
                         )
                     }

--- a/src/components/search/Results.js
+++ b/src/components/search/Results.js
@@ -37,13 +37,13 @@ const SearchResults = (props) => {
     <div className="content">
       <h3>{results.length} product(s) found matching your search</h3>
       {results.map(result => (
-        <strong><li onClick={() => props.history.push(`/products/${result.id}`)} key={result.id}>{result.title}</li></strong>
+        <li onClick={() => props.history.push(`/products/${result.id}`)} key={result.id} className="detail-link"><strong>{result.title}</strong></li>
       ))}
 
       <h3>{local.length} product(s) found with location matching your search</h3>
       
       {local.map(result => (
-        <strong><li onClick={() => props.history.push(`/products/${result.id}`)} key={result.id}>{result.title}</li></strong>
+        <li onClick={() => props.history.push(`/products/${result.id}`)} key={result.id} className="detail-link"><strong>{result.title}</strong></li>
       ))}
     </div>
     )

--- a/src/modules/ProductManager.js
+++ b/src/modules/ProductManager.js
@@ -19,6 +19,20 @@ export default {
   },
   getProductById(productId) {
     return fetch(`${authApiUrl}/products/${productId}`)
-        .then(resp => resp.json())
+        .then(response => response.json())
+  },
+  getProducts() {
+    return fetch(`${authApiUrl}/products`)
+      .then(response => response.json())
+  },
+  getProductsByUser() {
+    return fetch(`${authApiUrl}/products`, {
+        "method": "GET",
+        "headers": {
+            "Accept": "application/json",
+            "Authorization": `Token ${sessionStorage.getItem("bangazon-token")}`
+        }
+    })
+    .then(response => response.json())
   }
 }

--- a/src/modules/ProductManager.js
+++ b/src/modules/ProductManager.js
@@ -34,4 +34,12 @@ export default {
   getAllProducts() {
     return fetch(`${authApiUrl}/products`).then((response) => response.json());
   },
+  deleteProduct(productId) {
+    return fetch(`${authApiUrl}/products/${productId}`, {
+        "method": "DELETE",
+        "headers": {
+            "Authorization": `Token ${sessionStorage.getItem("bangazon-token")}`
+        }
+    })
+  }
 };

--- a/src/modules/ProductManager.js
+++ b/src/modules/ProductManager.js
@@ -22,7 +22,7 @@ export default {
         .then(response => response.json())
   },
   getProductsByUser() {
-    return fetch(`${authApiUrl}/products`, {
+    return fetch(`${authApiUrl}/products?user`, {
         "method": "GET",
         "headers": {
             "Accept": "application/json",


### PR DESCRIPTION
Closes #19 
Closes #51  

Summary:
- Added 'My Products' Page
- Added affordances to remove products
- Fixed clickable link areas on all product lists

Instructions:
- git fetch --all
- git checkout kw-view-remove-product-listing
- fetch and checkout branch from back-end pull request

Please Check:
- Only products that the currently logged in user has posted should display in the 'My Products' page
- Each product should be clickable, taking you to the product detail page
- Each product should have an affordance to remove the listing
- When the 'Remove Listing' button is clicked, the listing is removed from the database and disappears from the 'My Products' list
- All other pages where products are listed (home page, search results, etc) should show all products regardless of user
- All pages where products are listed should have links that are only clickable when you are actually hovering over the text